### PR TITLE
fully consume to avoid handle exhaustion

### DIFF
--- a/project/server/src/service/snapshot/defer/ingest.ts
+++ b/project/server/src/service/snapshot/defer/ingest.ts
@@ -172,8 +172,9 @@ export class SnapshotDeferIngest implements ISnapshotDeferIngest {
 							}
 						}
 					} else {
-						// close stream
-						await deferred.snapshot[Symbol.asyncIterator]().return?.();
+						// TODO: figure out alternative to fully consuming that doesn't slowly leak handles
+						for await (const _ of deferred.snapshot) {
+						}
 					}
 
 					await this.snapshot.finalize(handle, deferred.hassVersion);


### PR DESCRIPTION
creating iterator and calling return as well as  explicitly calling `.destroy` slowly leaks handles