### PR TITLE
also drain stream upon handle acquisition failure

### DIFF
--- a/project/server/src/service/snapshot/defer/ingest.ts
+++ b/project/server/src/service/snapshot/defer/ingest.ts
@@ -145,7 +145,11 @@ export class SnapshotDeferIngest implements ISnapshotDeferIngest {
 					logger.warn("handle acquisition failed for deferred ingest", {
 						id,
 						sub,
-					});
+          });
+
+					// TODO: figure out alternative to fully consuming that doesn't slowly leak handles
+					for await (const _ of deferred.snapshot) {
+					}
 
 					await this.snapshotDeferTarget.archive(id);
 


### PR DESCRIPTION
same thing as with 26757dff09365735da1b50abe9a0c6059db478ec, just in a prior branch