### PR TITLE
ci: pin actions to digests and enable renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,18 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    // keep GitHub Actions pinned to commit digests (Renovate maintains the # vX.Y.Z comment)
+    "helpers:pinGitHubActionDigests",
+    ":dependencyDashboard",
+    ":semanticCommits",
+  ],
+  baseBranchPatterns: ["main"],
+  packageRules: [
+    {
+      description: "Group all GitHub Actions digest bumps into a single PR",
+      matchManagers: ["github-actions"],
+      groupName: "github-actions",
+    },
+  ],
+}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,12 +17,12 @@ jobs:
       id-token: write
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           lfs: true
 
       - name: configure credentials
-        uses: aws-actions/configure-aws-credentials@0e613a0980cbf65ed5b322eb7a1e075d28913a83
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6.2.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -30,10 +30,10 @@ jobs:
 
       - name: login to ecr
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@62f4f872db3836360b72999f4b87f1ff13310f3a
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64  # v2.1.6
 
       - name: login to ghcr
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -46,14 +46,14 @@ jobs:
         run: echo "name=${REPO,,}" >> "$GITHUB_OUTPUT"
 
       - name: set up qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: build and push
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         env:
           ECR_TAG_LATEST: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:latest
           ECR_TAG_COMMIT: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ github.sha }}
@@ -73,7 +73,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: generate artifact attestation
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4.1.0
         with:
           subject-name: ghcr.io/${{ steps.repo.outputs.name }}
           subject-digest: ${{ steps.push.outputs.digest }}
@@ -81,14 +81,14 @@ jobs:
 
       - name: update task definition
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@c804dfbdd57f713b6c079302a4c01db7017a36fc
+        uses: aws-actions/amazon-ecs-render-task-definition@6853cfae8c3a7d978fbf68b5a55453395541dfbb  # v1.8.5
         with:
           task-definition: project/server/vendor/aws/ecs-task-definition.json
           container-name: ${{ vars.ECS_TASK_DEFINITION_CONTAINER_NAME }}
           image: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ github.sha }}
 
       - name: deploy task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c  # v2.6.2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ vars.ECS_SERVICE }}

--- a/.github/workflows/qa-client.yml
+++ b/.github/workflows/qa-client.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           lfs: true
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: npm
@@ -37,11 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           lfs: true
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: npm

--- a/.github/workflows/qa-server.yml
+++ b/.github/workflows/qa-server.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           lfs: true
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: npm
@@ -43,11 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           lfs: true
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: npm


### PR DESCRIPTION
## What

- Pin every GitHub Action across all workflows (`deploy.yaml`, `qa-client.yml`, `qa-server.yml`) to a commit SHA at its **latest** release, each annotated with a `# vX.Y.Z` comment.
- Add `.github/renovate.json5` to keep dependencies — including the pinned action digests — current.

## Actions pinned (latest release)

| Action | Version |
|---|---|
| actions/checkout | v7.0.0 |
| actions/setup-node | v6.4.0 |
| aws-actions/configure-aws-credentials | v6.2.0 |
| aws-actions/amazon-ecr-login | v2.1.6 |
| docker/login-action | v4.2.0 |
| docker/setup-qemu-action | v4.1.0 |
| docker/setup-buildx-action | v4.1.0 |
| docker/build-push-action | v7.2.0 |
| actions/attest | v4.1.0 |
| aws-actions/amazon-ecs-render-task-definition | v1.8.5 |
| aws-actions/amazon-ecs-deploy-task-definition | v2.6.2 |

## Renovate

- `helpers:pinGitHubActionDigests` keeps actions pinned to digests and maintains the version comments on bumps.
- Groups all Actions digest updates into a single PR; also covers npm lockfiles, Docker base images, and `.nvmrc`.

> Note: Renovate must be enabled on the repository (GitHub App / self-hosted) for the config to take effect.