### PR TITLE
chore(ci): repin setup-nomad to node24 commit

### DIFF
--- a/.github/workflows/deploy_sw.yml
+++ b/.github/workflows/deploy_sw.yml
@@ -135,7 +135,9 @@ jobs:
           tags: tag:ecosystem-device-database-release-action
 
       - name: Install Nomad CLI
-        uses: hashicorp/setup-nomad@ceba9087d4322dbdd7b35dafac5a87a8c459a157  # v1.0.0
+        # Pinned past v1.0.0 (still node20) to the main commit that moved the
+        # action onto node24; HashiCorp hasn't cut a new tag yet.
+        uses: hashicorp/setup-nomad@6e88df50dd00f3737f04fddde2bf2bd446e313dd  # node24, unreleased
         with:
           # renovate: datasource=github-releases depName=hashicorp/nomad
           version: "2.0.4"


### PR DESCRIPTION
## What

Repin `hashicorp/setup-nomad` in `deploy_sw.yml` from v1.0.0 (`ceba9087`) to the `main` commit `6e88df50` that moved the action onto node24.

## Why

The release deploy job emits a deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: hashicorp/setup-nomad@ceba9087...

v1.0.0 declares `using: "node20"`. HashiCorp already fixed this on `main` (`using: "node24"`) but **hasn't cut a new tag**, so this pins to that commit by full SHA.

## Caveat

v1.0.0 remains the only tagged release, so this pins to an untagged commit — immutable/safe via the SHA, but Renovate has no semver tag to track. Worth revisiting once HashiCorp ships a new tag.