### PR TITLE
ops: scope NOMAD_ADDR to the deploy step

### DIFF
--- a/.github/workflows/deploy_sw.yml
+++ b/.github/workflows/deploy_sw.yml
@@ -18,11 +18,6 @@ on:
   release:
     types: [published]
 
-env:
-  # Nomad HTTP API on the device-database host, reached over the tailnet
-  # (binds 0.0.0.0:4646, ACL on, plain HTTP). Override via a repo variable.
-  NOMAD_ADDR: ${{ secrets.NOMAD_ADDR }}
-
 permissions:
   contents: read
 
@@ -144,6 +139,9 @@ jobs:
 
       - name: Roll out new image tag
         env:
+          # Nomad HTTP API on the device-database host, reached over the tailnet.
+          # Override via a repo secret.
+          NOMAD_ADDR: ${{ secrets.NOMAD_ADDR }}
           NOMAD_TOKEN: ${{ secrets.NOMAD_TOKEN }}
           IMAGE_REF: ${{ needs.publish.outputs.image }}:${{ needs.publish.outputs.version }}
         run: |


### PR DESCRIPTION
## Summary
- `NOMAD_ADDR` was declared as a workflow-level `env`, which injected the secret into every step of both jobs — including the third-party actions in `publish` (checkout, buildx, GHCR login, metadata, attest) that have no use for it.
- Only the "Roll out new image tag" step reads it (the `echo` and the `nomad` CLI), so it's now declared in that step's `env` next to `NOMAD_TOKEN`.

## Test plan
- Workflow only runs on published releases; verified the only `$NOMAD_ADDR` references are within the step that now defines it.