### PR TITLE
make integration name non-optional

### DIFF
--- a/project/server/src/api/endpoint/derived/device/handler.ts
+++ b/project/server/src/api/endpoint/derived/device/handler.ts
@@ -2,6 +2,7 @@ import { Schema } from "effect";
 import type { PickDeep } from "type-fest";
 
 import integrations from "../../../../categorized-integrations.json";
+import { logger } from "../../../../logger";
 import {
 	DeviceCategoryIdValue,
 	DeviceConnectivityValue,
@@ -142,13 +143,19 @@ export const getDerivedDevices = (
 					? integrations[item.integration as Integration]
 					: undefined;
 
+				if (typeof integration === "undefined") {
+					logger.warn(
+						`integration definition missing for <${item.integration}>`,
+						{ integration: item.integration },
+					);
+
+					continue;
+				}
+
 				const independent = {
 					id: item.id,
 					integration: {
-						name:
-							typeof integration !== "undefined"
-								? integration.title
-								: undefined,
+						name: integration.title,
 						domain: item.integration,
 					},
 					manufacturer: item.manufacturer,
@@ -238,10 +245,21 @@ export const getDerivedDevice = (
 				? integrations[result.integration as Integration]
 				: undefined;
 
+			if (typeof integration === "undefined") {
+				logger.warn(
+					`integration definition missing for <${result.integration}>`,
+					{ integration: result.integration },
+				);
+
+				return {
+					code: 404,
+					body: "not found",
+				} as const;
+			}
+
 			const independent = {
 				integration: {
-					name:
-						typeof integration !== "undefined" ? integration.title : undefined,
+					name: integration.title,
 					domain: result.integration,
 				},
 				manufacturer: result.manufacturer,

--- a/schema/spec/derived/device.yaml
+++ b/schema/spec/derived/device.yaml
@@ -34,6 +34,7 @@ DerivedDeviceMono:
           type: object
           required:
             - domain
+            - name
           properties:
             name:
               type: string


### PR DESCRIPTION
integration manifest previously only included the names of integrations for which a category could be derived
this changed in 45fffb35370dc27fc11430a8f598eb765b98a6bd