### PR TITLE
semantic device deduplication

### DIFF
--- a/project/server/.zed/settings.json
+++ b/project/server/.zed/settings.json
@@ -1,25 +1,25 @@
 {
   "languages": {
     "JavaScript": {
-      "formatter": [
-        { "language_server": { "name": "biome" } },
-        { "code_action": "source.fixAll.biome" },
-        { "code_action": "source.organizeImports.biome" },
-      ],
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true,
+      },
     },
     "TypeScript": {
-      "formatter": [
-        { "language_server": { "name": "biome" } },
-        { "code_action": "source.fixAll.biome" },
-        { "code_action": "source.organizeImports.biome" },
-      ],
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true,
+      },
     },
     "TSX": {
-      "formatter": [
-        { "language_server": { "name": "biome" } },
-        { "code_action": "source.fixAll.biome" },
-        { "code_action": "source.organizeImports.biome" },
-      ],
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true,
+      },
     },
   },
   "language_servers": ["biome", "vtsls", "codebook"],

--- a/project/server/src/api/base.ts
+++ b/project/server/src/api/base.ts
@@ -209,7 +209,7 @@ export const idempotentEndpoint = <
 			? never
 			: Schema.Schema.Type<P>,
 		context: {
-			path: string;
+			path: `${string}${Path}${string}`;
 		},
 	) => Promise<
 		Code extends number ? EndpointResponse<Path, Method, Code> : never
@@ -250,7 +250,7 @@ export const idempotentEndpoint = <
 			async () => {
 				// biome-ignore lint/suspicious/noExplicitAny: types are checked above
 				return await handler(decodedParameters as any, {
-					path: target(new URL(c.req.url)),
+					path: target(new URL(c.req.url)) as `${string}${Path}${string}`,
 				});
 			},
 		);
@@ -331,7 +331,7 @@ export const effectfulEndpoint = <
 	Code extends keyof EndpointResponses<Path, Method>,
 	Contextualize extends EffectfulEndpointContext,
 	Context extends {
-		path: string;
+		path: `${string}${Path}${string}`;
 		raw: {
 			requestBody: Contextualize["raw"]["requestBody"] extends true
 				? ArrayBuffer

--- a/project/server/src/api/endpoint/derived/device/handler.ts
+++ b/project/server/src/api/endpoint/derived/device/handler.ts
@@ -4,12 +4,13 @@ import type { PickDeep } from "type-fest";
 import integrations from "../../../../categorized-integrations.json";
 import { logger } from "../../../../logger";
 import {
+	type DerivableDeviceMono,
 	DeviceCategoryIdValue,
 	DeviceConnectivityValue,
 } from "../../../../service/derive/derivable/device";
-import { Integer } from "../../../../type/codec/integer";
+import { floor, Integer } from "../../../../type/codec/integer";
 import { Uuid } from "../../../../type/codec/uuid";
-import { isNone } from "../../../../type/maybe";
+import { isNone, isSome } from "../../../../type/maybe";
 import { idempotentEndpoint } from "../../../base";
 import { paginate } from "../../../paginate";
 
@@ -17,10 +18,78 @@ import type { Dependency } from "../../../dependency";
 
 type Integration = keyof typeof integrations;
 
+const mapDevice = (d: Omit<DerivableDeviceMono, "duplicates">) => {
+	const integration = Object.keys(integrations).includes(d.integration)
+		? integrations[d.integration as Integration]
+		: undefined;
+
+	if (typeof integration === "undefined") {
+		logger.warn(`integration definition missing for <${d.integration}>`, {
+			integration: d.integration,
+		});
+
+		return null;
+	}
+
+	const independent = {
+		integration: {
+			name: integration.title,
+			domain: d.integration,
+		},
+		manufacturer: d.manufacturer,
+		first_encountered: d.firstEncounteredAt.toISOString(),
+		categories: d.categories,
+		connectivity: d.connectivity,
+		versions: {
+			software: d.versions.software.map((item) => ({
+				version: item.version,
+				active: item.active,
+				first_encountered: item.firstEncounteredAt.toISOString(),
+			})),
+			hardware: d.versions.hardware.map((item) => ({
+				version: item.version,
+				first_encountered: item.firstEncounteredAt.toISOString(),
+			})),
+		},
+		entities: d.entities.map((item) => ({
+			domain: item.domain,
+			original_device_class: item.originalDeviceClass,
+		})),
+		count: d.count,
+	} as const;
+
+	if (typeof d.model !== "undefined" && typeof d.modelId !== "undefined") {
+		return {
+			...independent,
+			model: d.model,
+			model_id: d.modelId,
+		} as const;
+	} else if (
+		typeof d.model !== "undefined" &&
+		typeof d.modelId === "undefined"
+	) {
+		return {
+			...independent,
+			model: d.model,
+		} as const;
+	} else if (
+		typeof d.model === "undefined" &&
+		typeof d.modelId !== "undefined"
+	) {
+		return {
+			...independent,
+			model_id: d.modelId,
+		} as const;
+	}
+
+	return null;
+};
+
 const ParametersDevices = Schema.Struct({
 	query: Schema.partial(
 		Schema.Struct({
 			term: Schema.String,
+			canonical: Schema.BooleanFromString,
 			manufacturer: Schema.Union(Schema.Array(Schema.String), Schema.String),
 			"!manufacturer": Schema.Union(Schema.Array(Schema.String), Schema.String),
 			category: Schema.Union(
@@ -61,6 +130,7 @@ export const getDerivedDevices = (
 					page,
 					size,
 					term,
+					canonical,
 					category: includeCategory,
 					"!category": excludeCategory,
 					connectivity: includeConnectivity,
@@ -73,6 +143,7 @@ export const getDerivedDevices = (
 		) => {
 			const query = {
 				term,
+				canonical: canonical ?? true,
 				include: {
 					categories:
 						typeof includeCategory !== "undefined"
@@ -137,76 +208,22 @@ export const getDerivedDevices = (
 				size,
 			});
 
-			const mapped = [];
-			for (const item of paginated.items) {
-				const integration = Object.keys(integrations).includes(item.integration)
-					? integrations[item.integration as Integration]
-					: undefined;
-
-				if (typeof integration === "undefined") {
-					logger.warn(
-						`integration definition missing for <${item.integration}>`,
-						{ integration: item.integration },
-					);
-
-					continue;
-				}
-
-				const independent = {
-					id: item.id,
-					integration: {
-						name: integration.title,
-						domain: item.integration,
-					},
-					manufacturer: item.manufacturer,
-					first_encountered: item.firstEncounteredAt.toISOString(),
-					categories: item.categories,
-					connectivity: item.connectivity,
-					versions: {
-						software: item.versions.software.map((item) => ({
-							version: item.version,
-							active: item.active,
-							first_encountered: item.firstEncounteredAt.toISOString(),
-						})),
-						hardware: item.versions.hardware.map((item) => ({
-							version: item.version,
-							first_encountered: item.firstEncounteredAt.toISOString(),
-						})),
-					},
-					entities: item.entities.map((item) => ({
-						domain: item.domain,
-						original_device_class: item.originalDeviceClass,
-					})),
-					count: item.count,
-				} as const;
-
-				if (
-					typeof item.model !== "undefined" &&
-					typeof item.modelId !== "undefined"
-				) {
-					mapped.push({
-						...independent,
-						model: item.model,
-						model_id: item.modelId,
-					});
-				} else if (
-					typeof item.model !== "undefined" &&
-					typeof item.modelId === "undefined"
-				) {
-					mapped.push({
-						...independent,
-						model: item.model,
-					});
-				} else if (
-					typeof item.model === "undefined" &&
-					typeof item.modelId !== "undefined"
-				) {
-					mapped.push({
-						...independent,
-						model_id: item.modelId,
-					});
-				}
-			}
+			const mapped = paginated.items.flatMap((device) => {
+				const mapped = mapDevice(device);
+				return isSome(mapped)
+					? [
+							{
+								...mapped,
+								id: device.id,
+								url: d.ingress.url.device.self(device.id).toString(),
+								duplicates: device.duplicates.map((id) => ({
+									id,
+									url: d.ingress.url.device.self(id).toString(),
+								})),
+							},
+						]
+					: [];
+			});
 
 			return {
 				code: 200,
@@ -241,87 +258,118 @@ export const getDerivedDevice = (
 				} as const;
 			}
 
-			const integration = Object.keys(integrations).includes(result.integration)
-				? integrations[result.integration as Integration]
-				: undefined;
-
-			if (typeof integration === "undefined") {
-				logger.warn(
-					`integration definition missing for <${result.integration}>`,
-					{ integration: result.integration },
-				);
-
+			const device = mapDevice(result);
+			if (isNone(device)) {
 				return {
 					code: 404,
 					body: "not found",
 				} as const;
 			}
 
-			const independent = {
-				integration: {
-					name: integration.title,
-					domain: result.integration,
-				},
-				manufacturer: result.manufacturer,
-				first_encountered: result.firstEncounteredAt.toISOString(),
-				categories: result.categories,
-				connectivity: result.connectivity,
-				versions: {
-					software: result.versions.software.map((item) => ({
-						version: item.version,
-						active: item.active,
-						first_encountered: item.firstEncounteredAt.toISOString(),
-					})),
-					hardware: result.versions.hardware.map((item) => ({
-						version: item.version,
-						first_encountered: item.firstEncounteredAt.toISOString(),
-					})),
-				},
-				entities: result.entities.map((item) => ({
-					domain: item.domain,
-					original_device_class: item.originalDeviceClass,
-				})),
-				count: result.count,
-			} as const;
+			const query = { canonical: new Set([id]) };
 
-			let combined;
-			if (
-				typeof result.model !== "undefined" &&
-				typeof result.modelId !== "undefined"
-			) {
-				combined = {
-					...independent,
-					model: result.model,
-					model_id: result.modelId,
-				} as const;
-			} else if (
-				typeof result.model !== "undefined" &&
-				typeof result.modelId === "undefined"
-			) {
-				combined = {
-					...independent,
-					model: result.model,
-				} as const;
-			} else if (
-				typeof result.model === "undefined" &&
-				typeof result.modelId !== "undefined"
-			) {
-				combined = {
-					...independent,
-					model_id: result.modelId,
-				} as const;
-			} else {
-				return {
-					code: 404,
-					body: "not found",
-				} as const;
-			}
+			const paginated = await paginate(d)({
+				slice: ({ offset, limit }) =>
+					d.derivable.device.devices.slice(query, { offset, limit }),
+				count: async () => await d.derivable.device.devices.count(query),
+			})({
+				path: d.ingress.url.device.duplicates(id),
+				page: floor(0),
+				size: undefined,
+			});
 
 			return {
 				code: 200,
-				body: combined,
+				body: {
+					...device,
+					duplicates: {
+						items: paginated.items.flatMap((device) => {
+							const mapped = mapDevice(device);
+							return isSome(mapped)
+								? [
+										{
+											...mapped,
+											id: device.id,
+											url: d.ingress.url.device.self(device.id).toString(),
+										},
+									]
+								: [];
+						}),
+						total: paginated.total,
+						next: paginated.links.next?.toString(),
+					},
+				},
 				headers: {
 					"cache-control": "max-age=1800",
+				},
+			} as const;
+		},
+	);
+
+const ParametersDeviceDuplicates = Schema.Struct({
+	path: Schema.Struct({
+		id: Uuid,
+	}),
+	query: Schema.partial(
+		Schema.Struct({
+			page: Schema.compose(Schema.NumberFromString, Integer),
+			size: Schema.compose(
+				Schema.NumberFromString.pipe(Schema.between(10, 50)),
+				Integer,
+			),
+		}),
+	),
+});
+
+export const getDerivedDeviceDuplicates = (
+	d: PickDeep<Dependency, "ingress" | "derivable.device">,
+) =>
+	idempotentEndpoint(
+		"/api/unstable/derived/devices/{id}/duplicates",
+		"get",
+		ParametersDeviceDuplicates,
+		async ({ path: { id }, query: { page, size } }, { path }) => {
+			const result = await d.derivable.device.device({ id });
+			if (isNone(result)) {
+				return {
+					code: 404,
+					body: "not found",
+				} as const;
+			}
+
+			const query = {
+				canonical: new Set([id]),
+			};
+
+			const paginated = await paginate(d)({
+				slice: ({ offset, limit }) =>
+					d.derivable.device.devices.slice(query, { offset, limit }),
+				count: async () => await d.derivable.device.devices.count(query),
+			})({
+				path,
+				page,
+				size,
+			});
+
+			const mapped = paginated.items.flatMap((device) => {
+				const mapped = mapDevice(device);
+				return isSome(mapped)
+					? [
+							{
+								...mapped,
+								id: device.id,
+								url: d.ingress.url.device.self(device.id).toString(),
+							},
+						]
+					: [];
+			});
+
+			return {
+				code: 200,
+				body: mapped,
+				headers: {
+					"cache-control": "max-age=1800",
+					...paginated.headers,
 				},
 			} as const;
 		},

--- a/project/server/src/api/endpoint/derived/index.ts
+++ b/project/server/src/api/endpoint/derived/index.ts
@@ -1,5 +1,13 @@
 import { primeRoutes } from "../../dependency";
-import { getDerivedDevice, getDerivedDevices } from "./device/handler";
+import {
+	getDerivedDevice,
+	getDerivedDeviceDuplicates,
+	getDerivedDevices,
+} from "./device/handler";
 
-const primed = primeRoutes(getDerivedDevices, getDerivedDevice);
+const primed = primeRoutes(
+	getDerivedDevices,
+	getDerivedDeviceDuplicates,
+	getDerivedDevice,
+);
 export default primed;

--- a/project/server/src/api/endpoint/dimension/handler.ts
+++ b/project/server/src/api/endpoint/dimension/handler.ts
@@ -53,6 +53,7 @@ export const getDimensions = (d: PickDeep<Dependency, "derivable.device">) =>
 		}) => {
 			const query = {
 				term,
+				canonical: true,
 				include: {
 					categories:
 						typeof includeCategory !== "undefined"

--- a/project/server/src/api/paginate.ts
+++ b/project/server/src/api/paginate.ts
@@ -1,3 +1,4 @@
+import { peek } from "../service/ingress";
 import { floor, type Integer } from "../type/codec/integer";
 import { unroll } from "../utility/iterable";
 
@@ -7,6 +8,13 @@ type Paginated<I> = {
 	headers: {
 		link: string;
 		"content-range": string;
+	};
+	total: number;
+	links: {
+		first: URL;
+		last: URL;
+		next?: URL;
+		prev?: URL;
 	};
 	items: I[];
 };
@@ -37,7 +45,7 @@ export const paginate =
 		page,
 		size,
 	}: {
-		path: string;
+		path: string | URL;
 		page: Integer | undefined;
 		size: Integer | undefined;
 	}) => Promise<Paginated<I>>) =>
@@ -50,11 +58,16 @@ export const paginate =
 
 		const counted = floor(await count());
 
+		const relationships = d.ingress.relationships(path, _page, _size, counted);
+		const peeked = peek(relationships);
+
 		return {
 			headers: {
-				link: d.ingress.header.link(path, _page, _size, counted),
+				link: d.ingress.header.link(relationships),
 				"content-range": contentRange(offset, _size, counted),
 			},
+			total: counted,
+			links: peeked,
 			items: counted > 0 ? await unroll(slice({ offset, limit: _size })) : [],
 		};
 	};

--- a/project/server/src/service/database/index.ts
+++ b/project/server/src/service/database/index.ts
@@ -15,6 +15,7 @@ import {
 	type DatabaseName,
 	peek,
 } from "./base";
+import { stdLoad } from "./std";
 import { Supervisor, type SupervisorWorkerPriority } from "./supervisor";
 
 import type { BoundQuery, ConnectionMode, Query, ResultMode } from "./query";
@@ -242,6 +243,7 @@ export class Database<DB extends DatabaseName | undefined>
 		this.db = new DatabaseSync(uri, {
 			timeout: 5000,
 		});
+		stdLoad(this.db);
 
 		logger.debug(`opened <${uri.pathname}>`, {
 			path: uri.pathname,

--- a/project/server/src/service/database/migration/derived/20260730150558.sql
+++ b/project/server/src/service/database/migration/derived/20260730150558.sql
@@ -1,0 +1,2 @@
+alter table derived_device add column derived_device_id_canonical text references derived_device(id) deferrable initially deferred;
+create index derived_device_derived_device_id_canonical_idx on derived_device(derived_device_id_canonical);

--- a/project/server/src/service/database/query/derived/device-get.sql
+++ b/project/server/src/service/database/query/derived/device-get.sql
@@ -6,6 +6,24 @@ with found as (
         derived_device
     where
         case
+            -- only include non-canonical devices
+            when @canonical = 0 then derived_device_id_canonical is not null
+            -- only include canonical devices
+            when @canonical = 1 then derived_device_id_canonical is null
+            -- include canonical and non-canonical devices
+            when @canonical is null then true
+            -- include only duplicates of given canonical devices
+            else derived_device_id_canonical in (
+                select value from json_each(@canonical)
+            )
+        end
+    intersect
+    select
+        id
+    from
+        derived_device
+    where
+        case
             when @includeManufacturers is not null then manufacturer in (select value from json_each(@includeManufacturers))
             else true
         end and
@@ -79,7 +97,19 @@ select
         from
             json_each(entities)
     ) entities,
-    count
+    count,
+    dd.derived_device_id_canonical "canonical",
+    case
+        when dd.derived_device_id_canonical is null then (
+            select
+                json_group_array(dd1.id)
+            from
+                derived_device dd1
+            where
+                dd1.derived_device_id_canonical = dd.id
+        )
+        else '[]'
+    end "duplicates"
 from
     found f join derived_device dd on (
         f.id = dd.id
@@ -121,14 +151,43 @@ select
         from
             json_each(entities)
     ) entities,
-    count
+    count,
+    dd.derived_device_id_canonical "canonical",
+    case
+        when dd.derived_device_id_canonical is null then (
+            select
+                json_group_array(dd1.id)
+            from
+                derived_device dd1
+            where
+                dd1.derived_device_id_canonical = dd.id
+        )
+        else '[]'
+    end "duplicates"
 from
-    derived_device
+    derived_device dd
 where
-    id = @id;
+    dd.id = @id;
 
 -- name: GetDerivedDevicesFiltersCounted :many
 with found as (
+    select
+        id
+    from
+        derived_device
+    where
+        case
+            -- only include non-canonical devices
+            when @canonical = 0 then derived_device_id_canonical is not null
+            -- only include canonical devices
+            when @canonical = 1 then derived_device_id_canonical is null
+            when @canonical is null then true
+            -- include only duplicates of given canonical devices
+            else derived_device_id_canonical in (
+                select value from json_each(@canonical)
+            )
+        end
+    intersect
     select
         id
     from

--- a/project/server/src/service/database/query/derived/device-insert.sql
+++ b/project/server/src/service/database/query/derived/device-insert.sql
@@ -14,56 +14,41 @@ with filtered_deduplicated_attribution_submission as (
         )
 ), filtered_device as materialized (
     select
-        ssd.*
+        ssd.id snapshot_submission_device_id
     from
         snapshot_submission_device ssd
     where
-        ssd.integration not in (
-            'apple_tv',
-            'braviatv',
-            'epson',
-            'home_connect',
-            'homekit_controller',
-            'hue_ble',
-            'husqvarna_automower_ble',
-            'insteon',
-            'iotawatt',
-            'isy944',
-            'lg_netcast',
-            'lg_thinq',
-            'litterrobot',
-            'neato',
-            'phillips_js',
-            'roborock',
-            'roon',
-            'samsungtv',
-            'squeezebox',
-            'system_bridge',
-            'tplink_omada',
-            'tuya',
-            'unifiiprotect',
-            'webmin',
-            'xiaomi_miio'
+        ssd.integration not in (select value from json_each(@ruleLiteralIntegration)) and
+        ssd.manufacturer not in (
+            select
+                distinct ssd1.manufacturer
+            from
+                snapshot_submission_device ssd1 join (
+                    select value from json_each(@rulePatternManufacturer)
+                ) r on (
+                    ssd1.manufacturer like r.value
+                )
         ) and
+        lower(ssd.manufacturer) not in (select lower(value) from json_each(@ruleLiteralManufacturer)) and
+        lower(ssd.model) not in (select lower(value) from json_each(@ruleLiteralModel)) and
         (
             ssd.manufacturer is not null and
             trim(ssd.manufacturer) != ''
         ) and
-        lower(ssd.manufacturer) not in (
-            'unknown',
-            'unknown manufacturer',
-            'undefined',
-            '(unknown)',
-            '?',
-            '--'
-        ) and
-        -- exclude tuya for insufficient data quality
-        ssd.manufacturer not like '_T%' and
         not (
             (ssd.model is null or trim(ssd.model) = '') and
             (ssd.model_id is null or trim(ssd.model_id) = '')
         ) and
-        ssd.model not like '% Tracked device'
+        ssd.model not in (
+            select
+                distinct ssd1.model
+            from
+                snapshot_submission_device ssd1 join (
+                    select value from json_each(@rulePatternModel)
+                ) r on (
+                    ssd1.model like r.value
+                )
+        )
 ), filtered_counted_device as materialized (
     select
         ssad.snapshot_submission_device_id,
@@ -75,13 +60,71 @@ with filtered_deduplicated_attribution_submission as (
     where
         ssad.snapshot_submission_device_id in (
             select
-                fd.id
+                fd.snapshot_submission_device_id
             from
                 filtered_device fd
         )
     group by 1
     having
         count(distinct fdas.subject) >= 5
+), filtered_counted_normalized_device_manufacturer as materialized (
+    select
+        distinct ssd.manufacturer manufacturer_original,
+        coalesce(
+            (
+                select
+                    value->>1
+                from
+                    json_each(@ruleAliasManufacturer)
+                where
+                    std_lower(value->>0) = std_lower(std_trim(std_nfkc(ssd.manufacturer))) or
+                    std_lower(value->>0) = std_lower(std_strip_corporate_designator(std_trim(std_nfkc(ssd.manufacturer))))
+            ),
+            first_value(std_strip_corporate_designator(std_trim(std_nfkc(ssd.manufacturer)))) over (
+                partition by
+                    std_lower(std_strip_corporate_designator(std_trim(std_nfkc(ssd.manufacturer))))
+                order by
+                    fcd.count desc
+            )
+        ) manufacturer_replacement
+    from
+        filtered_counted_device fcd join snapshot_submission_device ssd on (
+            fcd.snapshot_submission_device_id = ssd.id
+        )
+), filtered_counted_normalized_device as materialized (
+    select
+        fcd.snapshot_submission_device_id,
+        first_value(fcd.snapshot_submission_device_id) over (
+            partition by
+                (
+                    select
+                        manufacturer_replacement
+                    from
+                        filtered_counted_normalized_device_manufacturer
+                    where
+                        manufacturer_original = ssd.manufacturer
+                ),
+                coalesce(std_lower(std_trim(std_nfkc(ssd.model))), ''),
+                coalesce(std_lower(std_trim(std_nfkc(ssd.model_id))), '')
+            order by
+                fcd.count desc
+        ) snapshot_submission_device_id_canonical,
+        ssd.integration,
+        (
+            select
+                manufacturer_replacement
+            from
+                filtered_counted_normalized_device_manufacturer
+            where
+                manufacturer_original = ssd.manufacturer
+        ) manufacturer,
+        std_trim(std_nfkc(ssd.model)) model,
+        std_trim(std_nfkc(ssd.model_id)) model_id,
+        fcd.count
+    from
+        filtered_counted_device fcd join snapshot_submission_device ssd on (
+            fcd.snapshot_submission_device_id = ssd.id
+        )
 ), filtered_device_permutation as materialized (
    select
        ssdp.id snapshot_submission_device_permutation_id
@@ -202,10 +245,11 @@ insert into derived_device (
     versions_software,
     versions_hardware,
     entities,
-    count
+    count,
+    derived_device_id_canonical
 )
 select
-    ssd.id,
+    fcnd.snapshot_submission_device_id,
     integration,
     manufacturer,
     model,
@@ -218,8 +262,7 @@ select
                 fdds.snapshot_submission_id = ssad.snapshot_submission_id
             )
         where
-            ssad.snapshot_submission_device_id = ssd.id
-
+            ssad.snapshot_submission_device_id = fcnd.snapshot_submission_device_id
     ),
     (
         select
@@ -262,7 +305,7 @@ select
             from
                 snapshot_submission_device_permutation ssdp
             where
-                ssdp.snapshot_submission_device_id = ssd.id and
+                ssdp.snapshot_submission_device_id = fcnd.snapshot_submission_device_id and
                 version_sw is not null and
                 trim(version_sw) != '' and
                 version_sw != '""' and
@@ -306,7 +349,7 @@ select
             from
                 snapshot_submission_device_permutation ssdp
             where
-                ssdp.snapshot_submission_device_id = ssd.id and
+                ssdp.snapshot_submission_device_id = fcnd.snapshot_submission_device_id and
                 version_hw is not null and
                 trim(version_hw) != '' and
                 version_hw != '""' and
@@ -447,11 +490,18 @@ select
                     fed.snapshot_submission_entity_id = sse.id
                 )
             where
-                fed.snapshot_submission_device_id = ssd.id
+                fed.snapshot_submission_device_id = fcnd.snapshot_submission_device_id
         ) e
     ),
-    fcd.count
+    fcnd.count,
+    -- only populate when not the canonical device itself
+    case
+        when
+            fcnd.snapshot_submission_device_id != fcnd.snapshot_submission_device_id_canonical
+        then
+            fcnd.snapshot_submission_device_id_canonical
+        else
+            null
+    end
 from
-    filtered_counted_device fcd join snapshot_submission_device ssd on (
-        fcd.snapshot_submission_device_id = ssd.id
-    );
+    filtered_counted_normalized_device fcnd;

--- a/project/server/src/service/database/schema/derived/02_device.sql
+++ b/project/server/src/service/database/schema/derived/02_device.sql
@@ -9,5 +9,9 @@ create table derived_device (
     versions_software text not null default '[]',
     versions_hardware text not null default '[]',
     entities text not null default '[]',
-    count integer not null
+    count integer not null,
+    -- device with normalized attributes that appears more often
+    derived_device_id_canonical text references derived_device(id) deferrable initially deferred
 ) strict, without rowid;
+
+create index derived_device_derived_device_id_canonical_idx on derived_device(derived_device_id_canonical);

--- a/project/server/src/service/database/std.ts
+++ b/project/server/src/service/database/std.ts
@@ -1,0 +1,51 @@
+import type {
+	DatabaseSync,
+	FunctionOptions,
+	SQLInputValue,
+	SQLOutputValue,
+} from "node:sqlite";
+
+import { omit } from "../../utility/omit";
+
+const corporateDesignator =
+	/,?(?:(?: +| ?& ?|, ?| \+ )(?:b\.?v\.?|gmbh|kg|co\.?|inc\.?|ag|ltd\.?|a\/?s|sas|corp\.?|corporation|limited|ab|llc|s\.p\.a\.|sa|nv|s\.r\.o))+$/i;
+
+export const std = {
+	nfkc: {
+		deterministic: true,
+		fn: (text: SQLOutputValue) =>
+			typeof text === "string" ? text.normalize("NFKC") : null,
+	},
+	// built-in trim only removes literal space characters, not whitespace generally
+	trim: {
+		deterministic: true,
+		fn: (text: SQLOutputValue) =>
+			typeof text === "string" ? text.trim() : null,
+	},
+	// built-in lower only deals with ascii characters, while leaving any characters outside of range untouched
+	lower: {
+		deterministic: true,
+		fn: (text: SQLOutputValue) =>
+			typeof text === "string" ? text.toLowerCase() : null,
+	},
+	// built-in upper only deals with ascii characters, while leaving any characters outside of range untouched
+	upper: {
+		deterministic: true,
+		fn: (text: SQLOutputValue) =>
+			typeof text === "string" ? text.toUpperCase() : null,
+	},
+	strip_corporate_designator: {
+		deterministic: true,
+		fn: (text: SQLOutputValue) =>
+			typeof text === "string" ? text.replace(corporateDesignator, "") : null,
+	},
+} as const satisfies Record<
+	string,
+	FunctionOptions & { fn: (...args: SQLOutputValue[]) => SQLInputValue }
+>;
+
+export const stdLoad = (db: DatabaseSync) => {
+	for (const [name, definition] of Object.entries(std)) {
+		db.function(`std_${name}`, omit(definition, "fn"), definition.fn);
+	}
+};

--- a/project/server/src/service/database/worker.ts
+++ b/project/server/src/service/database/worker.ts
@@ -1,6 +1,8 @@
 import { DatabaseSync } from "node:sqlite";
 import { type MessagePort, parentPort, workerData } from "node:worker_threads";
 
+import { stdLoad } from "./std";
+
 import type { BoundQuery, ConnectionMode, ResultMode } from "./query";
 
 export type WorkerData = {
@@ -34,6 +36,7 @@ const db = new DatabaseSync(parsed, {
 		parsed.searchParams.get("mode") === "ro",
 	timeout: 5000,
 });
+stdLoad(db);
 
 for (const [key, value] of Object.entries(pragmas)) {
 	db.exec(`pragma ${key} = ${value}`);

--- a/project/server/src/service/derive/base.ts
+++ b/project/server/src/service/derive/base.ts
@@ -37,7 +37,7 @@ interface _DeriveDerivableClass<DB extends DatabaseName | undefined> {
 	new (...args: any[]): DeriveDerivableInstance<DB>;
 
 	get id(): symbol;
-	get schedule(): DeriveSchedule;
+	schedule?: DeriveSchedule;
 
 	/* identifiers of derivables that should be satisfied before deriving */
 	get prerequisites(): readonly symbol[];

--- a/project/server/src/service/derive/derivable/device/index.ts
+++ b/project/server/src/service/derive/derivable/device/index.ts
@@ -3,30 +3,31 @@ import { Schema } from "effect";
 import { isLeft } from "effect/Either";
 import { parseJson } from "effect/Schema";
 
-import { Category } from "../../../categories";
-import categories from "../../../categories.json" with { type: "json" };
-import categorizedIntegrations from "../../../categorized-integrations.json" with {
+import { Category } from "../../../../categories";
+import categories from "../../../../categories.json" with { type: "json" };
+import categorizedIntegrations from "../../../../categorized-integrations.json" with {
 	type: "json",
 };
-import { DateFromUnixTime } from "../../../type/codec/date";
-import { floor, Integer } from "../../../type/codec/integer";
-import { Uuid } from "../../../type/codec/uuid";
-import { isNone, isSome, type Maybe } from "../../../type/maybe";
+import { DateFromUnixTime } from "../../../../type/codec/date";
+import { floor, Integer } from "../../../../type/codec/integer";
+import { Uuid } from "../../../../type/codec/uuid";
+import { isNone, isSome, type Maybe } from "../../../../type/maybe";
 import {
 	counted,
 	type DatabaseTransaction,
 	IDatabaseDerived,
-} from "../../database";
-import { deleteDerivedDevices } from "../../database/query/derived/device-delete";
+} from "../../../database";
+import { deleteDerivedDevices } from "../../../database/query/derived/device-delete";
 import {
 	getDerivedDevice,
 	getDerivedDevices,
 	getDerivedDevicesFiltersCounted,
-} from "../../database/query/derived/device-get";
-import { insertDerivedDevices } from "../../database/query/derived/device-insert";
-import { DeriveDerivableSubject } from "./subject";
+} from "../../../database/query/derived/device-get";
+import { insertDerivedDevices } from "../../../database/query/derived/device-insert";
+import { DeriveDerivableSubject } from "../subject";
+import { alias, literal, pattern } from "./rules";
 
-import type { DeriveDerivable } from "../base";
+import type { DeriveDerivable } from "../../base";
 
 type DeviceModel =
 	| { model: string; modelId: string }
@@ -55,7 +56,7 @@ export type DeviceConnectivityValue = typeof DeviceConnectivityValue.Type;
 
 const isDeviceConnectivityValue = Schema.is(DeviceConnectivityValue);
 
-type MonoDevice = {
+export type DerivableDeviceMono = {
 	integration: string;
 	manufacturer: string;
 	categories?: DeviceCategory[] | undefined;
@@ -74,9 +75,10 @@ type MonoDevice = {
 	};
 	entities: { domain: string; originalDeviceClass?: string | undefined }[];
 	count: number;
+	duplicates: Uuid[];
 } & DeviceModel;
 
-type PolyDevice = MonoDevice & {
+type PolyDevice = DerivableDeviceMono & {
 	id: Uuid;
 };
 
@@ -86,16 +88,21 @@ type QueryMonoDevice = {
 
 type QueryPolyDevice = {
 	term?: string | undefined;
-	include: {
-		connectivities?: Set<DeviceConnectivityValue> | undefined;
-		categories?: Set<DeviceCategoryIdValue> | undefined;
-		manufacturers?: Set<string> | undefined;
-	};
-	exclude: {
-		connectivities?: Set<DeviceConnectivityValue> | undefined;
-		categories?: Set<DeviceCategoryIdValue> | undefined;
-		manufacturers?: Set<string> | undefined;
-	};
+	canonical?: Set<Uuid> | boolean | undefined;
+	include?:
+		| {
+				connectivities?: Set<DeviceConnectivityValue> | undefined;
+				categories?: Set<DeviceCategoryIdValue> | undefined;
+				manufacturers?: Set<string> | undefined;
+		  }
+		| undefined;
+	exclude?:
+		| {
+				connectivities?: Set<DeviceConnectivityValue> | undefined;
+				categories?: Set<DeviceCategoryIdValue> | undefined;
+				manufacturers?: Set<string> | undefined;
+		  }
+		| undefined;
 };
 
 const DeviceModelCodec = Schema.Union(
@@ -150,6 +157,8 @@ const DeviceCodec = Schema.extend(
 			),
 		),
 		count: Integer,
+		canonical: Schema.NullOr(Schema.String),
+		duplicates: parseJson(Schema.mutable(Schema.Array(Uuid))),
 	}),
 	DeviceModelCodec,
 );
@@ -181,7 +190,7 @@ export interface IDeriveDerivableDevice {
 		) => AsyncIterable<PolyDevice>;
 		count(query: QueryPolyDevice): Promise<Integer>;
 	};
-	device(query: QueryMonoDevice): Promise<Maybe<MonoDevice>>;
+	device(query: QueryMonoDevice): Promise<Maybe<DerivableDeviceMono>>;
 	filters(query: QueryPolyDevice): Promise<Filters>;
 }
 
@@ -354,7 +363,16 @@ export class DeriveDerivableDevice
 
 	async derive(t: DatabaseTransaction<"derived", "w">): Promise<void> {
 		await t.run(deleteDerivedDevices.bind.anonymous([]));
-		await t.run(insertDerivedDevices.bind.anonymous([]));
+		await t.run(
+			insertDerivedDevices.bind.named({
+				ruleLiteralIntegration: JSON.stringify(literal.integration),
+				ruleLiteralManufacturer: JSON.stringify(literal.manufacturer),
+				ruleLiteralModel: JSON.stringify(literal.model),
+				rulePatternManufacturer: JSON.stringify(pattern.manufacturer),
+				rulePatternModel: JSON.stringify(pattern.model),
+				ruleAliasManufacturer: JSON.stringify(alias.manufacturer),
+			}),
+		);
 	}
 
 	private static decoderDevice = Schema.decodeUnknownEither(DeviceCodec);
@@ -413,17 +431,22 @@ export class DeriveDerivableDevice
 		}
 	}
 
-	private static queryParameters({ term, include, exclude }: QueryPolyDevice) {
+	private static queryParameters({
+		term,
+		canonical,
+		include,
+		exclude,
+	}: QueryPolyDevice) {
 		const includeIntegrations =
 			DeriveDerivableDevice.queryParameterIntegrations(
-				include.categories,
-				include.connectivities,
+				include?.categories,
+				include?.connectivities,
 			);
 
 		const excludeIntegrations =
 			DeriveDerivableDevice.queryParameterIntegrations(
-				exclude.categories,
-				exclude.connectivities,
+				exclude?.categories,
+				exclude?.connectivities,
 			);
 
 		return {
@@ -434,12 +457,12 @@ export class DeriveDerivableDevice
 				? JSON.stringify(excludeIntegrations)
 				: null,
 			includeManufacturers:
-				typeof include.manufacturers !== "undefined" &&
+				typeof include?.manufacturers !== "undefined" &&
 				include.manufacturers.size > 0
 					? JSON.stringify([...include.manufacturers])
 					: null,
 			excludeManufacturers:
-				typeof exclude.manufacturers !== "undefined" &&
+				typeof exclude?.manufacturers !== "undefined" &&
 				exclude.manufacturers.size > 0
 					? JSON.stringify([...exclude.manufacturers])
 					: null,
@@ -447,6 +470,13 @@ export class DeriveDerivableDevice
 				// "%" and "_" characters have special meaning
 				.replaceAll("%", "\\%")
 				.replaceAll("_", "\\_")}%`,
+			canonical:
+				canonical instanceof Set
+					? JSON.stringify([...canonical])
+					: isSome(canonical)
+						? // sqlite doesn't like booleans → convert to 0 / 1
+							Number(canonical)
+						: null,
 		};
 	}
 
@@ -492,6 +522,7 @@ export class DeriveDerivableDevice
 					originalDeviceClass: item.originalDeviceClass ?? undefined,
 				})),
 				count: decoded.right.count,
+				duplicates: decoded.right.duplicates,
 			} as const;
 
 			if (isSome(decoded.right.model) && isSome(decoded.right.modelId)) {
@@ -534,7 +565,7 @@ export class DeriveDerivableDevice
 		count: this.devicesCount.bind(this),
 	};
 
-	async device(query: QueryMonoDevice): Promise<Maybe<MonoDevice>> {
+	async device(query: QueryMonoDevice): Promise<Maybe<DerivableDeviceMono>> {
 		const device = await this.db.run(getDerivedDevice.bind.named(query));
 		const decoded = DeriveDerivableDevice.decoderDevice(device);
 		if (isLeft(decoded)) {
@@ -557,6 +588,7 @@ export class DeriveDerivableDevice
 				originalDeviceClass: item.originalDeviceClass ?? undefined,
 			})),
 			count: decoded.right.count,
+			duplicates: decoded.right.duplicates,
 		} as const;
 
 		if (isSome(decoded.right.model) && isSome(decoded.right.modelId)) {

--- a/project/server/src/service/derive/derivable/device/rules.ts
+++ b/project/server/src/service/derive/derivable/device/rules.ts
@@ -1,0 +1,149 @@
+export const literal = {
+	// case-sensitive
+	integration: [
+		"apple_tv", // bridges devices, often with the wrong manufacturer
+		"braviatv", // model is user-editable
+		"epson", // only provides single, otherwise blank, device
+		"fully_kiosk", // data quality
+		"homekit_controller", // user-editable, roundtrips devices that have been exposed through "homekit"
+		"hue_ble", // provides significantly less data than "hue"
+		"husqvarna_automower_ble", // model part of model_id (as opposed to "husqvarna_automower" where model / model_id are set correctly)
+		"insteon", // always unfriendly model postfixed with two hex codes
+		"iotawatt", // only provides single, otherwise blank, device
+		"isy994", // just _really_ poor data quality
+		"lg_thinq", // model data quality
+		"litterrobot", // leaks pet breeds
+		"matter", // data quality
+		"neato", // mode data quality; cloud service discontinued
+		"onvif", // data quality
+		"roborock", // model data quality
+		"roon", // bridges devices without setting manufacturer correctly, user-editable
+		"samsungtv", // user-editable
+		"squeezebox", // user-editable
+		"system_bridge", // exclusively reports virtual devices
+		"tellduslive", // data quality
+		"tplink_omada", // software version in model
+		"tuya", // data quality
+		"upnp", // mix of virtual and real devices
+		"webmin", // exclusively reports virtual devices
+		"xiaomi_miio", // model data quality
+	],
+	// case-insensitive
+	manufacturer: [
+		"(unknown)",
+		"--",
+		"1",
+		"?",
+		"Home Assistant",
+		"HomeAssistant",
+		"Smartthi",
+		"TEST_VENDOR",
+		"august_manuf_name_here",
+		"boring test company",
+		"dummy manufacturer",
+		"ffff",
+		"generic",
+		"local",
+		"manufacturer",
+		"matter",
+		"unbranded",
+		"undefined",
+		"unk_manufacturer",
+		"unknown manufacturer",
+		"unknown",
+		"unspecified",
+		"Test",
+	],
+	// case-insensitive
+	model: ["august_model_number_here", "dummy"],
+};
+
+export const pattern = {
+	// case-insensitive
+	manufacturer: [
+		"%ONVIF%", // a standard for ip video cameras, not an actual manufacturer
+		"0x%", // some protocol integrations (mostly fritzbox, but sometimes also matter) provide internal manufacturer code instead of name
+		"TUYA%", // tuya whitelabel devices (insufficient data quality)
+		"_T%", // tuya whitelabel devices (insufficient data quality)
+		"%???%", // tuya whitelabel devices (insufficient data quality)
+	],
+	model: [
+		"%no model%",
+		"% Tracked device", // device tracking
+	],
+};
+
+export const alias = {
+	// case-insensitive
+	// generic suffixes ("Technologies", "Manufacturing", ...) are excluded, unless they are generally present in marketing material
+	// corporate designators are excluded ("GmbH", "A/S", "KG", ...)
+	manufacturer: [
+		["ASSA ABLOY Americas Residential", "ASSA ABLOY"],
+		["ASSA Abloy", "ASSA ABLOY"],
+		["ASSAABLOY", "ASSA ABLOY"],
+		["AVM Berlin", "FRITZ!"], // renamed itself (https://de.wikipedia.org/wiki/Fritz_(Elektronikhersteller))
+		["AVM", "FRITZ!"], // renamed itself (https://de.wikipedia.org/wiki/Fritz_(Elektronikhersteller))
+		["AdTrustMedia LLC dba: eZLO", "AdTrustMedia"],
+		["Amazon Technologies", "Amazon"],
+		["Amazon.com", "Amazon"],
+		["Anker Innovations Technology", "Anker"],
+		["Anker Technology", "Anker"],
+		["Anker", "Anker"],
+		["August Home", "August"],
+		["BMW Group", "BMW"],
+		["BMW_offline", "BMW"],
+		["Bang &amp; Olufsen A/S", "Bang & Olufsen"],
+		["Bang And Olufsen", "Bang & Olufsen"],
+		["BangOlufsen", "Bang & Olufsen"],
+		["Brilliant Home Technology", "Brilliant"],
+		["CentraLite", "Centralite Systems"],
+		["ELKO", "ELKO EP"],
+		["First Alert (BRK Brands Inc)", "First Alert"],
+		["GE_Appliances", "GE"],
+		["Google Nest", "Google"],
+		["Govee_vid", "Govee"],
+		["HARMAN International Industries, Incorporated", "HARMAN International"],
+		["HORNBACH Baumarkt", "HORNBACH"],
+		["Hewlett-Packard", "HP"],
+		["Hyundai_offline", "Hyundai"],
+		["Jasco Products Company", "Jasco"],
+		["Jasco Products", "Jasco"],
+		["Kia_offline", "Kia"],
+		["Kingston", "Kingston Technology"],
+		["LG Electronics", "LG"],
+		["Leviton", "Leviton Manufacturing"],
+		["LightSolutions Aps", "Light Solutions"],
+		["Linkplay Technology", "Linkplay"],
+		["Lutron Electronics", "Lutron"],
+		["MIUC Technology", "MIUC"],
+		["Mill International", "Mill"],
+		["Motionblinds, Coulisse", "Motionblinds"],
+		["NewOne", "New One"],
+		["Nuki Home Solutions", "Nuki"],
+		["Paulmann lamp", "Paulmann Licht"],
+		["Razer.Inc", "Razer"],
+		["SEI", "SEI Robotics"],
+		["SILICON_LABORATORIES", "Silicon Labs"],
+		["Samsung", "Samsung Electronics"],
+		["Sennheiser electronic GmbH &amp;", "Sennheiser"],
+		["Sennheiser electronic", "Sennheiser"],
+		["Shelly Europe", "Shelly"],
+		["Signify Netherlands", "Signify"],
+		["TCL Entertainment Solutions", "TCL"],
+		["Telldus Technologies", "Telldus"],
+		["Tesla_offline", "Tesla"],
+		["TexasInstruments", "Texas Instruments"],
+		["ThirdReality", "Third Reality"],
+		["U-Tec", "U-tec"],
+		["U-tec Group", "U-tec"],
+		["Ubiquiti Networks", "Ubiquiti"],
+		["Vestel", "Vestel Electronics"],
+		["Volkswagen_offline", "Volkswagen"],
+		["WD", "Western Digital"],
+		["Western Digital Technologies", "Western Digital"],
+		["YAMAHA AV AVS COMMON ACCOUNT", "Yamaha"],
+		["Yale Home", "Yale"],
+		["Zebra", "Zebra Technologies"],
+		["eWeLink Support Device", "eWeLink"],
+	],
+};

--- a/project/server/src/service/derive/derivable/subject.ts
+++ b/project/server/src/service/derive/derivable/subject.ts
@@ -10,10 +10,6 @@ export class DeriveDerivableSubject
 	static readonly id = Symbol("DeriveDerivableSubject");
 
 	static readonly prerequisites = [];
-	static readonly schedule = {
-		minute: "0",
-		hour: "*/1",
-	} as const;
 
 	async derive(t: DatabaseTransaction<"derived", "w">): Promise<void> {
 		await t.run(deleteDerivedSubjects.bind.anonymous([]));

--- a/project/server/src/service/derive/derivable/submission.ts
+++ b/project/server/src/service/derive/derivable/submission.ts
@@ -14,10 +14,6 @@ export class DeriveDerivableSubmissionFaulty
 	static readonly id = Symbol("DeriveDerivableSubmissionFaulty");
 
 	static readonly prerequisites = [];
-	static readonly schedule = {
-		minute: "0",
-		hour: "*/2",
-	} as const;
 
 	constructor(
 		private db = inject(IDatabaseDerived),

--- a/project/server/src/service/derive/index.test.ts
+++ b/project/server/src/service/derive/index.test.ts
@@ -10,10 +10,76 @@ import { Derive, DeriveWaitLateError } from ".";
 import type { DeriveDerivable } from "./base";
 
 test("plan", (t: TestContext) => {
+	// unscheduled derivable isn't included in plan unless its a prerequisite of another derivable
+	t.test("unscheduled", (t: TestContext) => {
+		class A implements DeriveDerivable<undefined, typeof A> {
+			static id = Symbol("A");
+
+			static prerequisites = [];
+
+			async derive(): Promise<void> {}
+		}
+
+		class B implements DeriveDerivable<undefined, typeof B> {
+			static id = Symbol("B");
+			static schedule = { minute: "30" } as const;
+
+			static prerequisites = [A.id];
+
+			async derive(): Promise<void> {}
+		}
+
+		{
+			const derive = new Derive(
+				new Database(
+					undefined,
+					bake({ location: new URL("file:?mode=memory") }),
+					{},
+				),
+				[new A()],
+				new StubIntrospection(),
+			);
+
+			const epoch = derive.next(
+				Derive.epoch(new Date("2026-03-03T17:29:00.000Z")),
+			);
+			const plan = derive.plan(epoch);
+			t.assert.ok(Derive.viable(plan));
+			t.assert.deepStrictEqual(
+				Derive.peek(plan).pending.map((item) => item.id),
+				[],
+			);
+		}
+
+		{
+			const derive = new Derive(
+				new Database(
+					undefined,
+					bake({ location: new URL("file:?mode=memory") }),
+					{},
+				),
+				[new A(), new B()],
+				new StubIntrospection(),
+			);
+
+			const epoch = derive.next(
+				Derive.epoch(new Date("2026-03-03T17:29:00.000Z")),
+			);
+			t.assert.deepStrictEqual(Derive.peek(epoch), {
+				next: new Date("2026-03-03T17:30:00.000Z"),
+			});
+			const plan = derive.plan(epoch);
+			t.assert.ok(Derive.viable(plan));
+			t.assert.deepStrictEqual(
+				Derive.peek(plan).pending.map((item) => item.id),
+				[A.id, B.id],
+			);
+		}
+	});
+
 	t.test("satisfiable", (t: TestContext) => {
 		class A implements DeriveDerivable<undefined, typeof A> {
 			static id = Symbol("A");
-			static schedule = {} as const;
 
 			static prerequisites = [];
 
@@ -70,7 +136,7 @@ test("plan", (t: TestContext) => {
 		t.assert.deepStrictEqual(
 			Derive.peek(plan).reasons,
 			new Map([
-				[A.id, new Set(["schedule", "dependency"])],
+				[A.id, new Set(["dependency"])],
 				[B.id, new Set(["schedule"])],
 				[C.id, new Set(["schedule", "dependency"])],
 				[D.id, new Set(["schedule"])],
@@ -90,7 +156,7 @@ test("plan", (t: TestContext) => {
 		t.assert.deepStrictEqual(
 			Derive.peek(plan).reasons,
 			new Map([
-				[A.id, new Set(["schedule", "dependency"])],
+				[A.id, new Set(["dependency"])],
 				[C.id, new Set(["schedule"])],
 			]),
 		);
@@ -108,7 +174,7 @@ test("plan", (t: TestContext) => {
 		t.assert.deepStrictEqual(
 			Derive.peek(plan).reasons,
 			new Map([
-				[A.id, new Set(["schedule", "dependency"])],
+				[A.id, new Set(["dependency"])],
 				[C.id, new Set(["schedule", "dependency"])],
 				[D.id, new Set(["schedule"])],
 			]),
@@ -127,7 +193,7 @@ test("plan", (t: TestContext) => {
 		t.assert.deepStrictEqual(
 			Derive.peek(plan).reasons,
 			new Map([
-				[A.id, new Set(["schedule", "dependency"])],
+				[A.id, new Set(["dependency"])],
 				[C.id, new Set(["schedule"])],
 			]),
 		);

--- a/project/server/src/service/derive/index.ts
+++ b/project/server/src/service/derive/index.ts
@@ -56,7 +56,7 @@ type DerivePlanUnachievable =
 
 type Derivable<DB extends DatabaseName | undefined> = {
 	id: symbol;
-	schedule: DeriveSchedule;
+	schedule?: DeriveSchedule | undefined;
 	derive: (t: DatabaseTransaction<DB, "w">) => Promise<void>;
 };
 
@@ -150,13 +150,11 @@ export class Derive<DB extends DatabaseName | undefined>
 			}
 
 			if (
-				!(
-					"schedule" in derivable.constructor &&
-					typeof derivable.constructor.schedule === "object"
-				)
+				"schedule" in derivable.constructor &&
+				typeof derivable.constructor.schedule !== "object"
 			) {
 				logger.error(
-					`malformed derivable <${derivable.constructor.name}>, missing #schedule`,
+					`malformed derivable <${derivable.constructor.name}>, misshapen #schedule`,
 					{
 						name: derivable.constructor.name,
 						description: derivable.constructor.id.description,
@@ -198,7 +196,10 @@ export class Derive<DB extends DatabaseName | undefined>
 
 			this.identified.set(derivable.constructor.id, {
 				id: derivable.constructor.id,
-				schedule: derivable.constructor.schedule as DeriveSchedule,
+				schedule:
+					"schedule" in derivable.constructor
+						? (derivable.constructor.schedule as DeriveSchedule)
+						: undefined,
 				derive: derivable.derive.bind(derivable),
 			});
 			this.prerequisites.set(derivable.constructor.id, _prerequisites);
@@ -298,6 +299,11 @@ export class Derive<DB extends DatabaseName | undefined>
 
 		let next: Date | undefined;
 		for (const { schedule } of this.identified.values()) {
+			// encountered derivable that doesn't have a set schedule
+			if (typeof schedule === "undefined") {
+				continue;
+			}
+
 			const parsed = Derive.parseSchedule(schedule, peeked.next);
 
 			const date = parsed.next().toDate();
@@ -452,6 +458,9 @@ export class Derive<DB extends DatabaseName | undefined>
 					return { kind: "missing-prerequisite", id: parentIdentifier };
 				}
 
+				if (typeof parent.schedule === "undefined") {
+					continue;
+				}
 				if (!this.pending(parent.schedule, next)) {
 					continue;
 				}
@@ -476,6 +485,9 @@ export class Derive<DB extends DatabaseName | undefined>
 						continue;
 					}
 
+					if (typeof child.schedule === "undefined") {
+						continue;
+					}
 					if (!this.pending(child.schedule, next)) {
 						continue;
 					}
@@ -507,6 +519,9 @@ export class Derive<DB extends DatabaseName | undefined>
 					continue;
 				}
 
+				if (typeof derivable.schedule === "undefined") {
+					continue;
+				}
 				if (!this.pending(derivable.schedule, next)) {
 					continue;
 				}

--- a/project/server/src/service/ingress/index.test.ts
+++ b/project/server/src/service/ingress/index.test.ts
@@ -82,7 +82,9 @@ test("formats link header style pagination", (t: TestContext) => {
 	);
 
 	t.test("first page of multi-page collection", (t: TestContext) => {
-		const link = ingress.header.link("/items", floor(0), floor(10), floor(50));
+		const link = ingress.header.link(
+			ingress.relationships("/items", floor(0), floor(10), floor(50)),
+		);
 
 		t.assert.ok(
 			link.includes('<https://example.com/items?size=10>; rel="first"'),
@@ -97,7 +99,9 @@ test("formats link header style pagination", (t: TestContext) => {
 	});
 
 	t.test("middle page includes prev and next", (t: TestContext) => {
-		const link = ingress.header.link("/items", floor(2), floor(10), floor(50));
+		const link = ingress.header.link(
+			ingress.relationships("/items", floor(2), floor(10), floor(50)),
+		);
 
 		t.assert.ok(
 			link.includes('<https://example.com/items?size=10>; rel="first"'),
@@ -114,7 +118,9 @@ test("formats link header style pagination", (t: TestContext) => {
 	});
 
 	t.test("last page has no next", (t: TestContext) => {
-		const link = ingress.header.link("/items", floor(4), floor(10), floor(50));
+		const link = ingress.header.link(
+			ingress.relationships("/items", floor(4), floor(10), floor(50)),
+		);
 
 		t.assert.ok(
 			link.includes('<https://example.com/items?size=10>; rel="first"'),
@@ -129,7 +135,9 @@ test("formats link header style pagination", (t: TestContext) => {
 	});
 
 	t.test("single page collection has no prev / next", (t: TestContext) => {
-		const link = ingress.header.link("/items", floor(0), floor(10), floor(5));
+		const link = ingress.header.link(
+			ingress.relationships("/items", floor(0), floor(10), floor(5)),
+		);
 
 		t.assert.ok(
 			link.includes('<https://example.com/items?size=10>; rel="first"'),
@@ -142,14 +150,18 @@ test("formats link header style pagination", (t: TestContext) => {
 	});
 
 	t.test("page beyond end has no prev / next", (t: TestContext) => {
-		const link = ingress.header.link("/items", floor(10), floor(10), floor(50));
+		const link = ingress.header.link(
+			ingress.relationships("/items", floor(10), floor(10), floor(50)),
+		);
 
 		t.assert.ok(!link.includes('rel="next"'));
 		t.assert.ok(!link.includes('rel="prev"'));
 	});
 
 	t.test("includes size in all urls", (t: TestContext) => {
-		const link = ingress.header.link("/items", floor(1), floor(25), floor(100));
+		const link = ingress.header.link(
+			ingress.relationships("/items", floor(1), floor(25), floor(100)),
+		);
 
 		const urls = [...link.matchAll(/<([^>]+)>/g)].map((m) => new URL(m[1]));
 		for (const url of urls) {
@@ -158,7 +170,9 @@ test("formats link header style pagination", (t: TestContext) => {
 	});
 
 	t.test("start with count not evenly divisible by size", (t: TestContext) => {
-		const link = ingress.header.link("/items", floor(0), floor(10), floor(53));
+		const link = ingress.header.link(
+			ingress.relationships("/items", floor(0), floor(10), floor(53)),
+		);
 
 		t.assert.ok(
 			link.includes('<https://example.com/items?size=10>; rel="first"'),
@@ -173,7 +187,9 @@ test("formats link header style pagination", (t: TestContext) => {
 	});
 
 	t.test("middle with count not evenly divisible by size", (t: TestContext) => {
-		const link = ingress.header.link("/items", floor(3), floor(10), floor(53));
+		const link = ingress.header.link(
+			ingress.relationships("/items", floor(3), floor(10), floor(53)),
+		);
 
 		t.assert.ok(
 			link.includes('<https://example.com/items?size=10>; rel="first"'),
@@ -190,7 +206,9 @@ test("formats link header style pagination", (t: TestContext) => {
 	});
 
 	t.test("last with count not evenly divisible by size", (t: TestContext) => {
-		const link = ingress.header.link("/items", floor(4), floor(10), floor(53));
+		const link = ingress.header.link(
+			ingress.relationships("/items", floor(4), floor(10), floor(53)),
+		);
 
 		t.assert.ok(
 			link.includes('<https://example.com/items?size=10>; rel="first"'),
@@ -204,7 +222,9 @@ test("formats link header style pagination", (t: TestContext) => {
 	});
 
 	t.test("empty collection", (t: TestContext) => {
-		const link = ingress.header.link("/items", floor(0), floor(10), floor(0));
+		const link = ingress.header.link(
+			ingress.relationships("/items", floor(0), floor(10), floor(0)),
+		);
 
 		t.assert.ok(
 			link.includes('<https://example.com/items?size=10>; rel="first"'),
@@ -216,10 +236,7 @@ test("formats link header style pagination", (t: TestContext) => {
 
 	t.test("preserves search parameters", (t: TestContext) => {
 		const link = ingress.header.link(
-			"/items?foo=bar",
-			floor(0),
-			floor(10),
-			floor(0),
+			ingress.relationships("/items?foo=bar", floor(0), floor(10), floor(0)),
 		);
 
 		t.assert.ok(

--- a/project/server/src/service/ingress/index.ts
+++ b/project/server/src/service/ingress/index.ts
@@ -6,24 +6,50 @@ import { type Parameters, paths } from "../../web/base";
 import { DatabaseSnapshotVoucherPayload } from "../../web/database/snapshot/base";
 import { IVoucher, type SealedVoucher, Voucher } from "../voucher";
 
+import type { Uuid } from "../../type/codec/uuid";
+
+const RelationshipsSymbol = Symbol("LinkRel");
+type Relationships = {
+	[RelationshipsSymbol]: {
+		first: URL;
+		last: URL;
+		prev?: URL;
+		next?: URL;
+	};
+};
+
+export const peek = (relationshipts: Relationships) =>
+	relationshipts[RelationshipsSymbol];
+
 export interface IIngress {
 	origin: string;
 	header: {
-		/**
-		 * @param path path segment of url
-		 * @param page current page, starting at 0
-		 * @param size requested page size
-		 * @param count overall count of items in collection
-		 */
-		link(path: string, page: Integer, size: Integer, count: Integer): string;
+		link(relationships: Relationships): string;
 	};
+	/**
+	 * @param path path segment of url
+	 * @param page current page, starting at 0
+	 * @param size requested page size
+	 * @param count overall count of items in collection
+	 */
+	relationships(
+		path: string | URL,
+		page: Integer,
+		size: Integer,
+		count: Integer,
+	): Relationships;
 	url: {
+		device: {
+			self(id: Uuid): URL;
+			duplicates(id: Uuid): URL;
+		};
+
 		databaseSnapshot(
 			sealed: SealedVoucher<
 				"database-snapshot",
 				DatabaseSnapshotVoucherPayload
 			>,
-		): string;
+		): URL;
 	};
 }
 
@@ -39,17 +65,18 @@ export class Ingress implements IIngress {
 		return `${this.external.secure ? "https" : "http"}://${this.external.authority}`;
 	}
 
-	private headerLink(
-		path: string,
+	public relationships(
+		path: string | URL,
 		page: Integer,
 		size: Integer,
 		count: Integer,
-	) {
+	): Relationships {
 		// pages are 0-indexed
 		const last = ceil(count / size - 1);
 
 		const url = (page: Integer, size: Integer) => {
-			const url = new URL(path, this.origin);
+			const url =
+				typeof path === "string" ? new URL(path, this.origin) : new URL(path);
 			url.searchParams.delete("page");
 			url.searchParams.delete("size");
 			if (page > 0) {
@@ -60,10 +87,10 @@ export class Ingress implements IIngress {
 			return url;
 		};
 
-		const relationships: string[] = [
-			`<${url(floor(0), size)}>; rel="first"`,
-			`<${url(last, size)}>; rel="last"`,
-		];
+		const rel: Relationships[typeof RelationshipsSymbol] = {
+			first: url(floor(0), size),
+			last: url(last, size),
+		};
 
 		prev: {
 			const prev = floor(page - 1);
@@ -77,7 +104,7 @@ export class Ingress implements IIngress {
 				break prev;
 			}
 
-			relationships.push(`<${url(prev, size)}>; rel="prev"`);
+			rel.prev = url(prev, size);
 		}
 
 		next: {
@@ -87,19 +114,48 @@ export class Ingress implements IIngress {
 				break next;
 			}
 
-			relationships.push(`<${url(next, size)}>; rel="next"`);
+			rel.next = url(next, size);
 		}
 
-		return relationships.join(", ");
+		return { [RelationshipsSymbol]: rel };
+	}
+
+	private headerLink(relationships: Relationships): string {
+		const rel = relationships[RelationshipsSymbol];
+		const parts: string[] = [
+			`<${rel.first}>; rel="first"`,
+			`<${rel.last}>; rel="last"`,
+		];
+
+		if (rel.prev) {
+			parts.push(`<${rel.prev}>; rel="prev"`);
+		}
+
+		if (rel.next) {
+			parts.push(`<${rel.next}>; rel="next"`);
+		}
+
+		return parts.join(", ");
 	}
 
 	header = {
 		link: this.headerLink.bind(this),
 	};
 
+	private urlDeviceSelf(id: Uuid) {
+		return new URL(`/api/unstable/derived/devices/${id}`, this.origin);
+	}
+
+	private urlDeviceDuplicates(id: Uuid) {
+		return new URL(
+			`/api/unstable/derived/devices/${id}/duplicates`,
+			this.origin,
+		);
+	}
+
 	private urlDatabaseSnapshotStale(
 		sealed: SealedVoucher<"database-snapshot", DatabaseSnapshotVoucherPayload>,
-	): string {
+	): URL {
 		const path = paths["database-snapshot"];
 		const query = {
 			voucher: this.voucher.serialize(sealed, DatabaseSnapshotVoucherPayload),
@@ -108,10 +164,17 @@ export class Ingress implements IIngress {
 		const peeked = Voucher.peek(sealed);
 
 		// `:name` is set so that name of downloaded file reflects the coordinator name
-		return `${this.origin}${path.replace(":name", `${peeked.coordinator}.db`)}?${new URLSearchParams(query).toString()}`;
+		return new URL(
+			`${path.replace(":name", `${peeked.coordinator}.db`)}?${new URLSearchParams(query).toString()}`,
+			this.origin,
+		);
 	}
 
 	url = {
+		device: {
+			self: this.urlDeviceSelf.bind(this),
+			duplicates: this.urlDeviceDuplicates.bind(this),
+		},
 		databaseSnapshot: this.urlDatabaseSnapshotStale.bind(this),
 	};
 }

--- a/schema/spec/derived/device.yaml
+++ b/schema/spec/derived/device.yaml
@@ -122,26 +122,37 @@ DerivedDeviceMono:
               type: string
             model_id:
               type: string
-DerivedDeviceMonoCounted:
+
+DerivedDeviceMonoCountedDeduplicated:
   allOf:
     - $ref: "#/DerivedDeviceMono"
     - type: object
       required:
         - count
+        - duplicates
       properties:
         count:
           type: integer
+        duplicates:
+          type: object
+          required:
+            - items
+            - total
+          properties:
+            items:
+              type: array
+              items:
+                $ref: "#/DerivedDevicePolyCounted"
+            total:
+              type: integer
+            next:
+              type: string
+              format: uri
 
 DerivedDevicePoly:
   allOf:
     - $ref: "#/DerivedDeviceMono"
-    - type: object
-      required:
-        - id
-      properties:
-        id:
-          type: string
-          format: uuid
+    - $ref: "../snippet.yaml#/SnippetRef"
 DerivedDevicePolyCounted:
   allOf:
     - $ref: "#/DerivedDevicePoly"
@@ -151,3 +162,14 @@ DerivedDevicePolyCounted:
       properties:
         count:
           type: integer
+DerivedDevicePolyCountedDeduplicated:
+  allOf:
+    - $ref: "#/DerivedDevicePolyCounted"
+    - type: object
+      required:
+        - duplicates
+      properties:
+        duplicates:
+          type: array
+          items:
+            $ref: "../snippet.yaml#/SnippetRef"

--- a/schema/spec/main.yaml
+++ b/schema/spec/main.yaml
@@ -198,6 +198,11 @@ paths:
             type: string
             pattern: '^\d*$'
         - in: query
+          name: canonical
+          schema:
+            type: string
+            enum: ["true", "false"]
+        - in: query
           name: term
           schema:
             type: string
@@ -255,7 +260,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "derived/device.yaml#/DerivedDevicePolyCounted"
+                  $ref: "derived/device.yaml#/DerivedDevicePolyCountedDeduplicated"
 
   /api/unstable/derived/devices/{id}:
     get:
@@ -278,7 +283,53 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "derived/device.yaml#/DerivedDeviceMonoCounted"
+                $ref: "derived/device.yaml#/DerivedDeviceMonoCountedDeduplicated"
+        "404":
+          description: "device not found"
+          content:
+            text/plain:
+              schema:
+                type: string
+                const: not found
+
+  /api/unstable/derived/devices/{id}/duplicates:
+    get:
+      operationId: getDerivedDeviceDuplicates
+      parameters:
+        - in: path
+          required: true
+          name: id
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: string
+            pattern: '^\d*$'
+        - in: query
+          name: size
+          schema:
+            type: string
+            pattern: '^\d*$'
+      responses:
+        "200":
+          description: "duplicate derived devices"
+          headers:
+            link:
+              $ref: "snippet.yaml#/SnippetPaginationLink"
+            content-range:
+              $ref: "snippet.yaml#/SnippetPaginationContentRange"
+            cache-control:
+              required: true
+              schema:
+                type: string
+                const: "max-age=1800"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "derived/device.yaml#/DerivedDevicePolyCounted"
         "404":
           description: "device not found"
           content:

--- a/schema/spec/snippet.yaml
+++ b/schema/spec/snippet.yaml
@@ -20,3 +20,15 @@ SnippetPaginationContentRange:
   schema:
     type: string
   example: items 0-30/7210
+
+SnippetRef:
+  type: object
+  required:
+    - id
+    - href
+  properties:
+    id:
+      type: string
+    url:
+      type: string
+      format: uri

--- a/schema/src/spec/bundle.ts
+++ b/schema/src/spec/bundle.ts
@@ -41,6 +41,13 @@ let bundled: BundleResult;
 	bundled = await bundle({ ref: spec, config, dereference: false });
 }
 
+if (bundled.problems.length > 0) {
+	console.error("bundling failed");
+	for (const problem of bundled.problems) {
+		console.error(problem.message);
+	}
+}
+
 let serialized: string | undefined;
 const extension = extname(values.out);
 switch (extension) {


### PR DESCRIPTION
refactors device aggregation query to source exclusion and newly introduced aliasing rules from query parameters, that are populated with contents of the [rules definition file](https://github.com/OHF-Device-Database/device-database/blob/0360326ce8693099b2e453668ef10d9f5ed21ff1/project/server/src/service/derive/derivable/device/rules.ts)

also introduces concept of semantic device duplicates, based on their normalized manufacturer / model / model identifier
the normalized device with the most unique submissions is considered the original, with others being hidden by default in **`GET /api/unstable/derived/devices`** and **`GET /api/unstable/dimensions`** endpoint
normalization happens according to manually defined rules (e.g. manufacturer name aliases), but also through stripping of corporate designators (e.g. "Google Inc." → "Google") and unicode normalization

duplicates are exposed through a new `"duplicates"` field in **`GET /api/unstable/derived/devices/{id}`** (full representation, paginated) and **`GET /api/unstable/derived/devices`** (only identifiers, paginated) endpoint
also introduces a new endpoint **`GET /api/unstable/derived/devices/{id}/duplicates`** to browse all duplicates of a given device

fixes #184